### PR TITLE
Octopress support and selectable scaling

### DIFF
--- a/gallery_generator.rb
+++ b/gallery_generator.rb
@@ -46,6 +46,7 @@ module Jekyll
       best_image = nil
       max_size_x = 400
       max_size_y = 400
+      scale_method = site.config["gallery"]["scale_method"] || "fit"
       begin
         max_size_x = site.config["gallery"]["thumbnail_size"]["x"]
       rescue
@@ -72,7 +73,7 @@ module Jekyll
           if File.file?("#{thumbs_dir}/#{image}") == false or File.mtime("#{dir}/#{image}") > File.mtime("#{thumbs_dir}/#{image}")
             begin
               m_image = ImageList.new("#{dir}/#{image}")
-              m_image.resize_to_fit!(max_size_x, max_size_y)
+              m_image.send("resize_to_#{scale_method}!", max_size_x, max_size_y)
               puts "Writing thumbnail to #{thumbs_dir}/#{image}"
               m_image.write("#{thumbs_dir}/#{image}")
             rescue


### PR DESCRIPTION
Noticed that using gallery generator in subdirectories (Like source/ in octopress), makes the thumbs disappear after generation, as the path is incorrectly set for subdirectories, in static_files. This should fix the issue for octopress.

Note: This could probably be made more general, to fix issues for other folders than source.

Also, I added a feature, allowing you to set scale method in config, to allow for "fill-scaling", as I use resize_to_fill to generate square thumbnails.

Thanks for a great, tiny plugin :)
