### PR TITLE
Styles in gallery index are made not inline, but in style tag

### DIFF
--- a/lib/gallery_index.html
+++ b/lib/gallery_index.html
@@ -1,10 +1,21 @@
 ---
 layout: page
 ---
+<style TYPE="text/css">
+.gallery-wrapper {
+  width: 35em;
+  text-align: center;
+  padding: 1em 0 4em 0;
+}
+.gallery-best-image{
+  max-height: 20em;
+  max-width: 20em;
+}
+</style>
 {% for gallery in page.galleries %}
-<div style="width: 35em; text-align: center; padding: 1em 0 4em 0;">
+<div class="gallery-wrapper">
     <a href="{{ gallery['gallery'] }}">
-        <img style="max-height: 20em; max-width: 20em;" src="{{ gallery['gallery'] }}/thumbs/{{ gallery['best_image'] }}">
+        <img class="gallery-best-image" src="{{ gallery['gallery'] }}/thumbs/{{ gallery['best_image'] }}">
     </a>
     <h3><a href="{{ gallery['gallery'] }}">{{ gallery["name"] }}</a></h3>
     {{ gallery["images"] | size }} images


### PR DESCRIPTION
Greetings from Russia, comrads!

It seems to be not very good to put style actually into tag attributes. 
In gallery_page.html was appropritae style tag, but there wasn't one in gallery_index.html
So, I added.

Доброго времени суток, товарищи!
В файле gallery_page.html стили были вынесены в тэг style, а в gallery_index.html - нет. Теперь там тоже вынесены, ибо неаккуратно.
