### PR TITLE
Update link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Gallery Generator
 
-This is a [Jekyll plugin](https://github.com/mojombo/jekyll/wiki/Plugins) that generates galleries from directories full of images. It uses [RMagick](http://rmagick.rubyforge.org/) to create thumbnails.
+This is a [Jekyll plugin](http://jekyllrb.com/docs/plugins/) that generates galleries from directories full of images. It uses [RMagick](http://rmagick.rubyforge.org/) to create thumbnails.
 
 This plugin is quite minimalist. It generates galleries with no pagination, no sub-galleries, and no descriptions. [See my gallery](http://geoff.greer.fm/photos/) for an example of what it looks like.
 


### PR DESCRIPTION
Link to Jekyll plug-ins simple redirects. I've update it to just be the place it redirects to.