### PR TITLE
Properly pluralise image count

### DIFF
--- a/lib/gallery_index.html
+++ b/lib/gallery_index.html
@@ -18,6 +18,6 @@ layout: page
         <img class="gallery-best-image" src="{{ gallery['gallery'] }}/thumbs/{{ gallery['best_image'] }}">
     </a>
     <h3><a href="{{ gallery['gallery'] }}">{{ gallery["name"] }}</a></h3>
-    {{ gallery["images"] | size }} images
+    {{ gallery["images"] | size }} image{% if gallery["images"].size != 1 %}s{% endif %}
 </div>
 {% endfor %}


### PR DESCRIPTION
If there's only one image, it should say "1 image" instead of "1 images"