### PR TITLE
Images are not correctly aligned within wrapper

### DIFF
--- a/lib/gallery_page.html
+++ b/lib/gallery_page.html
@@ -8,7 +8,6 @@ layout: page
   display: inline-block;
   margin: 1em;
   position: relative;
-  text-align: center;
 }
 .gallery-image {
   margin: auto;


### PR DESCRIPTION
The images were aligned to the center, but this moved them a bit to the right side and then half of them were outside the wrapper, which leads to the right half of the picture being not clickable.

Remove this line to align them to left and correctly inside the wrapper. Otherwise the right side may not be clickable (tested with Google Chrome 42)

![pr](https://cloud.githubusercontent.com/assets/1507474/7200994/f48edec0-e502-11e4-8f52-e628a5211012.png)