### PR TITLE
Write orientation to thumbnail images

### DIFF
--- a/lib/jekyll-gallery-generator.rb
+++ b/lib/jekyll-gallery-generator.rb
@@ -162,6 +162,7 @@ module Jekyll
         if File.file?(thumb_path) == false or File.mtime(image_path) > File.mtime(thumb_path)
           begin
             m_image = ImageList.new(image_path)
+            m_image.auto_orient!
             m_image.send("resize_to_#{scale_method}!", max_size_x, max_size_y)
             puts "Writing thumbnail to #{thumb_path}"
             m_image.write(thumb_path)


### PR DESCRIPTION
With this PR the orientation of the images EXIF data is written to the thumbnail.
This is helpful when, for example, using a justified layout like described here: https://github.com/miromannino/Justified-Gallery/issues/111