### PR TITLE
RMagick deprecation warning, nil conversion error

### DIFF
--- a/lib/jekyll-gallery-generator.rb
+++ b/lib/jekyll-gallery-generator.rb
@@ -1,5 +1,5 @@
 require 'exifr'
-require 'RMagick'
+require 'rmagick'
 include Magick
 
 include FileUtils
@@ -16,15 +16,15 @@ module Jekyll
   class ReadYamlPage < Page
     def read_yaml(base, name, opts = {})
       begin
-        self.content = File.read(File.join(base, name), merged_file_read_opts(opts))
+        self.content = File.read(File.join(base.to_s, name.to_s), merged_file_read_opts(opts))
         if content =~ /\A(---\s*\n.*?\n?)^((---|\.\.\.)\s*$\n?)/m
           self.content = $POSTMATCH
           self.data = SafeYAML.load($1)
         end
       rescue SyntaxError => e
-        Jekyll.logger.warn "YAML Exception reading #{File.join(base, name)}: #{e.message}"
+        Jekyll.logger.warn "YAML Exception reading #{File.join(base.to_s, name.to_s)}: #{e.message}"
       rescue Exception => e
-        Jekyll.logger.warn "Error reading file #{File.join(base, name)}: #{e.message}"
+        Jekyll.logger.warn "Error reading file #{File.join(base.to_s, name.to_s)}: #{e.message}"
       end
 
       self.data ||= {}
@@ -193,7 +193,7 @@ module Jekyll
       site.static_files = @site.static_files
       self.data["images"] = @images
       self.data["best_image"] = gallery_config["best_image"] || best_image
-      best_image_path = File.join(dir, best_image)
+      best_image_path = File.join(dir.to_s, best_image.to_s)
       begin
         self.data["date_time"] = EXIFR::JPEG.new(best_image_path).date_time.to_i
       rescue Exception => e


### PR DESCRIPTION
- fixed deprecation warning:
  -> use rmagick instead of RMagick
- fixed "error generating galleries: no implicit conversion of nil into String"
  -> implicit conversion to String of operands in join