### PR TITLE
Replace hyphens with spaces in gallery names

### DIFF
--- a/lib/jekyll-gallery-generator.rb
+++ b/lib/jekyll-gallery-generator.rb
@@ -115,7 +115,7 @@ module Jekyll
       self.read_yaml(File.dirname(gallery_page), File.basename(gallery_page))
       self.data["gallery"] = gallery_name
       gallery_title_prefix = config["title_prefix"] || "Photos: "
-      gallery_name = gallery_name.gsub("_", " ").gsub(/\w+/) {|word| word.capitalize}
+      gallery_name = gallery_name.gsub(/[_-]/, " ").gsub(/\w+/) {|word| word.capitalize}
       begin
         gallery_name = gallery_config["name"] || gallery_name
       rescue


### PR DESCRIPTION
Hyphens are, in my experience, more common in paths than underscores, so I think this could be useful.