### PR TITLE
Add Gallery Info Feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,9 @@ gallery:
       sort_reverse: true    # Reverse sort images in gallery.
     secret_stuff:
       hidden: true          # Don't show this gallery on the index page. People must guess the URL.
+    with_info:
+      info:
+        desc: "Gallery Description" # Info fields can be used in custom templates.
 ```
 
 

--- a/lib/jekyll-gallery-generator.rb
+++ b/lib/jekyll-gallery-generator.rb
@@ -293,4 +293,3 @@ module Jekyll
     end
   end
 end
-

--- a/lib/jekyll-gallery-generator.rb
+++ b/lib/jekyll-gallery-generator.rb
@@ -255,6 +255,8 @@ module Jekyll
         gallery_date_time = 0
       end
       self.data["date_time"] = gallery_date_time
+
+      self.data["info"] = gallery_config["info"]
     end
   end
 
@@ -291,3 +293,4 @@ module Jekyll
     end
   end
 end
+

--- a/lib/jekyll-gallery-generator.rb
+++ b/lib/jekyll-gallery-generator.rb
@@ -256,7 +256,7 @@ module Jekyll
       end
       self.data["date_time"] = gallery_date_time
 
-      self.data["info"] = gallery_config["info"]
+      self.data["info"] = gallery_config["info"] if gallery_config.key?("info")
     end
   end
 


### PR DESCRIPTION
Adds a minimal gallery info feature where if `info` key is present in the gallery description in config.yml it will be made available in the gallery page for use in custom templates. Updated README with an example.