### PR TITLE
Note Ruby version requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,11 +39,14 @@ IMG_1039.JPG  IMG_1046.JPG  IMG_1057.JPG
 * [ImageMagick](http://www.imagemagick.org/)
 * [RMagick](https://github.com/rmagick/rmagick)
 * [exifr](https://github.com/remvee/exifr/)
+* [Ruby](https://www.ruby-lang.org) >= 2.1
 
 ### Install dependencies on OS X
 
 ```bash
-brew install imagemagick
+brew install imagemagick rbenv
+rbenv install 2.4.0
+rbenv global 2.4.0
 gem install rmagick exifr
 ```
 


### PR DESCRIPTION
macOS ships with Ruby 2.0.0, and Jekyll itself requires only >2.0.0. This plugin uses `to_h` so users need to install a more recent version of Ruby. I've noted this in the readme to avoid future confusion.