### PR TITLE
Change require statements in the gem's main file

### DIFF
--- a/lib/jekyll-gallery-generator.rb
+++ b/lib/jekyll-gallery-generator.rb
@@ -1,4 +1,4 @@
-require 'exifr'
+require 'exifr/jpeg'
 require 'rmagick'
 include Magick
 


### PR DESCRIPTION
This commit should fix the error `uninitialized constant EXIFR::JPEG`
that used to occur during `jekyll build`.